### PR TITLE
Add minimal task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# tesko
+# Task Manager App
+
+This simple Python application helps you keep track of recurring tasks for each weekday and provides a quick notes section. It uses the built-in `tkinter` library for a minimal user interface and stores data in `tasks.json`.
+
+## Requirements
+- Python 3 with tkinter (most Python distributions include tkinter by default)
+
+## Usage
+1. Install Python 3 if not already installed.
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Add or check off tasks for each day of the week.
+4. Use the **Notes** tab to store quick thoughts and click **Save Notes** to save them.
+
+All data is saved to `tasks.json` in the same directory.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,95 @@
+import json
+import os
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+DATA_FILE = 'tasks.json'
+
+def load_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    # Default structure
+    data = {day: [] for day in ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']}
+    data['notes'] = ''
+    return data
+
+def save_data(data):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+class TaskApp(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title('Task Manager')
+        self.geometry('400x400')
+        self.resizable(False, False)
+
+        self.data = load_data()
+        self.task_vars = {day: [] for day in self.data if day != 'notes'}
+
+        self.notebook = ttk.Notebook(self)
+        self.notebook.pack(fill='both', expand=True)
+
+        for day in ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']:
+            frame = ttk.Frame(self.notebook)
+            self.notebook.add(frame, text=day)
+            self.build_day_tab(frame, day)
+
+        self.build_notes_tab()
+
+    def build_day_tab(self, frame, day):
+        tasks = self.data.get(day, [])
+        container = ttk.Frame(frame)
+        container.pack(fill='both', expand=True, padx=10, pady=10)
+
+        for task in tasks:
+            var = tk.BooleanVar(value=task.get('done', False))
+            chk = ttk.Checkbutton(container, text=task['text'], variable=var, command=self.save)
+            chk.pack(anchor='w')
+            self.task_vars[day].append((var, task))
+
+        entry_var = tk.StringVar()
+        entry = ttk.Entry(container, textvariable=entry_var)
+        entry.pack(fill='x', pady=(10,0))
+
+        def add_task():
+            text = entry_var.get().strip()
+            if text:
+                task = {'text': text, 'done': False}
+                var = tk.BooleanVar(value=False)
+                chk = ttk.Checkbutton(container, text=text, variable=var, command=self.save)
+                chk.pack(anchor='w')
+                self.task_vars[day].append((var, task))
+                self.save()
+                entry_var.set('')
+        add_btn = ttk.Button(container, text='Add Task', command=add_task)
+        add_btn.pack(pady=5)
+
+    def build_notes_tab(self):
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text='Notes')
+
+        text = tk.Text(frame, wrap='word')
+        text.pack(fill='both', expand=True)
+        text.insert('1.0', self.data.get('notes', ''))
+
+        def save_notes():
+            self.data['notes'] = text.get('1.0', 'end').rstrip()
+            save_data(self.data)
+            messagebox.showinfo('Saved', 'Notes saved.')
+
+        btn = ttk.Button(frame, text='Save Notes', command=save_notes)
+        btn.pack(pady=5)
+
+    def save(self):
+        for day, vars_tasks in self.task_vars.items():
+            self.data[day] = []
+            for var, task in vars_tasks:
+                task['done'] = var.get()
+                self.data[day].append(task)
+        save_data(self.data)
+
+if __name__ == '__main__':
+    app = TaskApp()
+    app.mainloop()

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,11 @@
+{
+  "Monday": [
+    {"text": "analyzing MF and updating Brief", "done": false},
+    {"text": "sending AB emails", "done": false}
+  ],
+  "Tuesday": [],
+  "Wednesday": [],
+  "Thursday": [],
+  "Friday": [],
+  "notes": ""
+}


### PR DESCRIPTION
## Summary
- build a minimal Tkinter-based task manager
- include default `tasks.json` with example tasks
- document usage in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688b67e2594c8324a7252a9a43006f63